### PR TITLE
Guarantee async effects

### DIFF
--- a/src/Concur/React.purs
+++ b/src/Concur/React.purs
@@ -2,15 +2,17 @@ module Concur.React where
 
 import Prelude
 
-import Concur.Core (Widget, WidgetStep(WidgetStep), mapView, orr, unWidget)
+import Concur.Core (Widget, WidgetStep(..), mapView, orr, unWidget)
 import Control.Monad.Aff (runAff_)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (log)
-import Control.Monad.Eff.Unsafe (unsafeCoerceEff)
 import Control.Monad.Free (resume)
 import Control.Monad.IO (runIO')
 import Control.Monad.IOSync (runIOSync')
 import Data.Either (Either(..))
+import Data.Maybe (Maybe(..))
+import Partial.Unsafe (unsafeCrashWith)
+import React (spec')
 import React as R
 import React.DOM as D
 import React.DOM.Props as P
@@ -26,23 +28,40 @@ el' :: forall a. NodeName -> Array (Widget HTML a) -> Widget HTML a
 el' n = el n <<< orr
 
 componentClass :: forall props a. Widget HTML a -> R.ReactClass props
-componentClass winit = R.createClass (R.spec' init render)
+componentClass winit = R.createClass spec
   where
-    init this = discharge (unWidget winit) this
-    discharge w this = case resume w of
-      Right _ -> pure []
+    spec = (spec' init render) { componentDidMount = componentDidMount }
+
+    init this =
+      case resume (unWidget winit) of
+        Right _ -> pure { view: [], cont: Nothing }
+        Left (WidgetStep mws) -> runIOSync' do
+          ws <- mws
+          pure { view: ws.view, cont: Just ws.cont }
+
+    componentDidMount this = do
+      ws <- R.readState this
+      case ws.cont of
+        Nothing -> unsafeCrashWith "Nothing to render"
+        Just cont -> runAff_ (handler this) $ runIO' cont
+
+    discharge this w = case resume w of
+      Right _ -> pure unit
       Left (WidgetStep mws) -> runIOSync' do
         ws <- mws
+        void $ liftEff $ R.writeState this { view: ws.view, cont: Nothing }
         liftEff $ runAff_ (handler this) $ runIO' ws.cont
-        pure ws.view
-    handler this (Right r) = do
-      v <- discharge r this
-      void $ unsafeCoerceEff $ R.writeState this v
-    handler _ (Left err) = do
-      log ("FAILED! " <> show err)
-      pure unit
+
+    handler this = case _ of
+      Right r -> discharge this r
+      Left err -> do
+        log ("FAILED! " <> show err)
+        pure unit
+
     -- TODO: Refine the div wrapper. This is just a placeholder.
-    render this = D.div' <$> R.readState this
+    render this = do
+      { view } <- R.readState this
+      pure $ D.div' view
 
 renderComponent :: forall a. Widget HTML a -> R.ReactElement
 renderComponent init = R.createFactory (componentClass init) {}


### PR DESCRIPTION
Guarantee that all async effects are in fact async by forcing this at the driver level. The current `affAction` is problematic because it doesn't properly clean up the losing side of `<|>`.

This fixes the issue by guaranteeing that the `IO` is always run after the view has been rendered.