### PR TITLE
bumped to purescript 0.15.4, spago 0.20.9, fixed ES Module exports ne…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purescript-concur-react",
-  "version": "0.3.8",
+  "version": "0.5.0",
   "description": "Concur UI framework for Purescript, React backend",
   "license": "MIT",
   "repository": "purescript-concur/purescript-concur-react",
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.4",
-    "purescript": "^0.13.6",
+    "purescript": "^0.15.4",
     "rimraf": "^3.0.2",
-    "spago": "^0.15.2"
+    "spago": "^0.20.9"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -108,29 +108,37 @@ let additions =
 -------------------------------
 -}
 
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190626/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20210118/packages.dhall sha256:a59c5c93a68d5d066f3815a89f398bcf00e130a51cb185b2da29b20e2d8ae115
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.4-20220725/packages.dhall
+        sha256:e56fbdf33a5afd2a610c81f8b940b413a638931edb41532164e641bb2a9ec29c
 
-let overrides = { concur-react = ./spago.dhall as Location }
+in upstream
+  with concur-core = 
+    { dependencies =
+        [ "aff"
+        , "aff-bus"
+        , "arrays"
+        , "avar"
+        , "console"
+        , "control"
+        , "datetime"
+        , "effect"
+        , "either"
+        , "exceptions"
+        , "foldable-traversable"
+        , "free"
+        , "identity"
+        , "lazy"
+        , "maybe"
+        , "newtype"
+        , "parallel"
+        , "prelude"
+        , "profunctor-lenses"
+        , "tailrec"
+        , "transformers"
+        , "tuples"
+        ]
+    , repo = "https://github.com/drshade/purescript-concur-core"
+    , version = "v0.5.0"
+    }
 
-let additions =
-      { concur-core =
-          mkPackage
-            [ "aff"
-            , "arrays"
-            , "avar"
-            , "console"
-            , "foldable-traversable"
-            , "free"
-            , "nonempty"
-            , "profunctor-lenses"
-            , "tailrec"
-            ]
-            "https://github.com/purescript-concur/purescript-concur-core"
-            "v0.4.2"
-      }
-
-in  upstream // overrides // additions

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,28 +2,28 @@
 Welcome to a Spago project!
 You can edit this file as you like.
 -}
-{ name =
-    "concur-react"
+{ name = "concur-react"
 , dependencies =
-    [ "aff"
-    , "arrays"
-    , "avar"
-    , "console"
-    , "concur-core"
-    , "foldable-traversable"
-    , "free"
-    , "nonempty"
-    , "profunctor-lenses"
-    , "react"
-    , "react-dom"
-    , "tailrec"
-    , "web-dom"
-    , "web-html"
-    ]
+  [ "aff"
+  , "arrays"
+  , "concur-core"
+  , "console"
+  , "effect"
+  , "either"
+  , "exceptions"
+  , "maybe"
+  , "prelude"
+  , "react"
+  , "react-dom"
+  , "transformers"
+  , "tuples"
+  , "unsafe-coerce"
+  , "web-dom"
+  , "web-events"
+  , "web-html"
+  ]
 , license = "MIT"
 , repository = "https://github.com/purescript-concur/purescript-concur-react"
-, packages =
-    ./packages.dhall
-, sources =
-    [ "src/**/*.purs", "test/**/*.purs" ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/src/Concur/React/Props.js
+++ b/src/Concur/React/Props.js
@@ -1,6 +1,6 @@
 "use strict";
 
-exports.resetTargetValue = function(s) {
+export const resetTargetValue = function(s) {
     return function(event) {
         return function() {
             event.target.value = s;
@@ -8,4 +8,4 @@ exports.resetTargetValue = function(s) {
     };
 };
 
-exports.emptyProp_ = {}
+export const emptyProp_ = {}


### PR DESCRIPTION
Similar to the PR opened against concur-core a few moments ago - please look at that one first!

This currently points to my own clone of concur-core temporarily so that it works. Once you have merged the concur-core you would obviously point back to the main repo (in packages.dhall). 

Once this is all done it would be great if we could campaign to get this included in the latest psc-0.15 package set - i would be happy to help make that happen. 

All the best,
Tom